### PR TITLE
Add follow-up scheduling controls

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ TyphoonLineWebhook is a LINE-based chatbot designed to provide support and guida
 
 - **Conversational Support**: Engages users in supportive dialogue about substance use concerns
 - **Risk Assessment**: Automatically detects high-risk keywords and provides emergency resources
-- **Follow-up System**: Scheduled follow-ups to check on user progress (1, 3, 7, 14, and 30-day intervals)
+- **Follow-up System**: Scheduled follow-ups to check on user progress with customizable days
 - **Progress Tracking**: Monitors user interactions and risk levels over time
 - **Session Management**: Maintains conversation context with timeout notifications
 - **Multi-component Architecture**: Uses Redis for caching, MySQL for persistent storage, and LINE for messaging
@@ -186,6 +186,9 @@ Logs are stored in the `logs/` directory and rotated automatically when they rea
 | `/emergency` | Display emergency contacts |
 | `/feedback` | Provide feedback |
 | `/progress` | View progress report |
+| `/setfollowup` | Set custom follow-up days |
+| `/cancelfollowup` | Cancel all follow-ups |
+| `/followup` | Show time until next follow-up |
 
 ### Monitoring
 


### PR DESCRIPTION
## Summary
- allow users to set custom follow-up days with `/setfollowup`
- let users cancel follow-ups using `/cancelfollowup`
- clear all follow-ups on `/reset`
- document new commands

## Testing
- `python -m py_compile app/app_main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6853fdd255e08320a5b67fe9869c23bd